### PR TITLE
refactor: envReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Escale
 
-Módulos helpers para uso em projetos em Go da Escale.
+Biblioteca padrão para projetos Golang da Escale.
 
 ## Como usar
 ```
@@ -8,4 +8,4 @@ go get github.com/escaletech/go-escale
 ```
 
 ## Funcionalidades
-[readEnv](./docs/readEnv.md)
+[envreader](./docs/envreader.md)

--- a/docs/envreader.md
+++ b/docs/envreader.md
@@ -1,4 +1,4 @@
-# readEnv
+# envreader
 
 Funções para validação de variáveis de ambiente.
 

--- a/envreader/main.go
+++ b/envreader/main.go
@@ -1,0 +1,24 @@
+package envreader
+
+import "strings"
+
+// Create a new envReader
+func NewEnvReader(env func(key string) string) *EnvReader {
+	return &EnvReader{
+		Env: env,
+	}
+}
+
+// Check if envReader Errs slice is not empty
+func (r *EnvReader) HasErrors() bool {
+	if len(r.Errs) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// Returns envReader Errs slice items as a string
+func (r *EnvReader) GetErrors() string {
+	return strings.Join(r.Errs, ", ")
+}

--- a/envreader/string.go
+++ b/envreader/string.go
@@ -1,4 +1,4 @@
-package readenv
+package envreader
 
 import "github.com/escaletech/go-escale/messages"
 

--- a/envreader/type.go
+++ b/envreader/type.go
@@ -1,0 +1,6 @@
+package envreader
+
+type EnvReader struct {
+	Errs []string
+	Env  func(key string) string
+}

--- a/readenv/type.go
+++ b/readenv/type.go
@@ -1,6 +1,0 @@
-package readenv
-
-type EnvReader struct {
-	Errs []string
-	Env func(key string) string
-}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,10 +2,11 @@ sonar.projectKey=go-escale
 sonar.projectName=go-escale
 
 sonar.sources=.
-sonar.exclusions=**/test/**/*.go, **/messages/*.go
+sonar.exclusions=**/**/*_test.go, **/messages/*.go
 
 sonar.tests=.
-sonar.test.inclusions=**/test/**/*.go
+sonar.test.inclusions=**/**/*_test.go
+
 
 sonar.go.coverage.reportPaths=coverage.out
 sonar.go.tests.reportPaths=report.json

--- a/test/envreader/main_test.go
+++ b/test/envreader/main_test.go
@@ -1,0 +1,56 @@
+package envreader_test
+
+import (
+	"testing"
+
+	"github.com/escaletech/go-escale/envreader"
+	"github.com/escaletech/go-escale/messages"
+	testUtils "github.com/escaletech/go-escale/test/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(t *testing.T) {
+	t.Run("HasErrors", func(t *testing.T) {
+		t.Run("envReader errs slice is empty", func(t *testing.T) {
+			t.Run("returns false", func(t *testing.T) {
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
+
+				assert.Equal(t, false, r.HasErrors())
+			})
+		})
+
+		t.Run("envReader errs slice has items", func(t *testing.T) {
+			t.Run("returns false", func(t *testing.T) {
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
+
+				r.StringRequired("WHATEVER")
+
+				assert.Equal(t, true, r.HasErrors())
+			})
+		})
+	})
+
+	t.Run("GetErrors", func(t *testing.T) {
+		t.Run("envReader errs slice has items", func(t *testing.T) {
+			t.Run("returns items as a string", func(t *testing.T) {
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
+
+				r.StringRequired("WHATEVER")
+				r.StringRequired("WHATEVER2")
+
+				expectedErrs := messages.MissingRequiredEnv("WHATEVER") + ", " + messages.MissingRequiredEnv("WHATEVER2")
+
+				assert.Equal(t, expectedErrs, r.GetErrors())
+			})
+		})
+
+		t.Run("envReader errs slice is empty", func(t *testing.T) {
+			t.Run("returns an empty string", func(t *testing.T) {
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
+
+				assert.Equal(t, "", r.GetErrors())
+			})
+		})
+	})
+}

--- a/test/envreader/string_test.go
+++ b/test/envreader/string_test.go
@@ -1,48 +1,31 @@
-package readenv_test
+package envreader_test
 
 import (
 	"testing"
 
+	"github.com/escaletech/go-escale/envreader"
 	"github.com/escaletech/go-escale/messages"
-	"github.com/escaletech/go-escale/readenv"
+	testUtils "github.com/escaletech/go-escale/test/utils"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var fakeEnvVarName = "fakeEnv"
-var fakeEnvVarValue = "fakeEnvValue"
-
-func getFakeEnv(key string) string {
-	if key == fakeEnvVarName {
-		return fakeEnvVarValue
-	} 
-
-	return ""
-}
-
-func newEnvReader() readenv.EnvReader{
-	return readenv.EnvReader{
-		Env: getFakeEnv,
-	}
-}
-
 func TestString(t *testing.T) {
-
-	t.Run("StringRequired", func(t *testing.T) { 
+	t.Run("StringRequired", func(t *testing.T) {
 		t.Run("Env has the required value", func(t *testing.T) {
 			t.Run("It should return the variable value and error's slice should be empty", func(t *testing.T) {
-				r := newEnvReader()
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
 
-				response := r.StringRequired(fakeEnvVarName)
+				response := r.StringRequired(testUtils.FakeEnvVarName)
 
-				assert.Equal(t, fakeEnvVarValue, response)
-				assert.Equal(t, 0, len(r.Errs) )
+				assert.Equal(t, testUtils.FakeEnvVarValue, response)
+				assert.Equal(t, false, r.HasErrors())
 			})
 		})
 
 		t.Run("Env doesn't have the required value", func(t *testing.T) {
 			t.Run("It should return an empty string and add an error message to the slice", func(t *testing.T) {
-				r := newEnvReader()
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
 
 				response := r.StringRequired("invalidEnvVarName")
 
@@ -52,26 +35,26 @@ func TestString(t *testing.T) {
 		})
 	})
 
-	t.Run("StringOrDefault", func(t *testing.T) { 
+	t.Run("StringOrDefault", func(t *testing.T) {
 		t.Run("Env has the required value", func(t *testing.T) {
 			t.Run("It should return the variable value and error's slice should be empty", func(t *testing.T) {
-				r := newEnvReader()
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
 
-				response := r.StringOrDefault(fakeEnvVarName, "defaultValue")
+				response := r.StringOrDefault(testUtils.FakeEnvVarName, "defaultValue")
 
-				assert.Equal(t, fakeEnvVarValue, response)
-				assert.Equal(t, 0, len(r.Errs) )
+				assert.Equal(t, testUtils.FakeEnvVarValue, response)
+				assert.Equal(t, false, r.HasErrors())
 			})
 		})
 
 		t.Run("Env doesn't have the required value", func(t *testing.T) {
 			t.Run("It should return a default value and error's slice should be empty", func(t *testing.T) {
-				r := newEnvReader()
+				r := envreader.NewEnvReader(testUtils.GetFakeEnv)
 
 				response := r.StringOrDefault("invalidEnvVarName", "defaultValue")
 
 				assert.Equal(t, "defaultValue", response)
-				assert.Equal(t, 0, len(r.Errs))
+				assert.Equal(t, false, r.HasErrors())
 			})
 		})
 	})

--- a/test/utils/envReaderUtils.go
+++ b/test/utils/envReaderUtils.go
@@ -1,0 +1,12 @@
+package test_utils
+
+var FakeEnvVarName = "fakeEnv"
+var FakeEnvVarValue = "fakeEnvValue"
+
+func GetFakeEnv(key string) string {
+	if key == FakeEnvVarName {
+		return FakeEnvVarValue
+	}
+
+	return ""
+}


### PR DESCRIPTION
- Renomeia o package `readenv` para `envreader`;
- Adiciona as funções `hasErrors` e `getErrors`;
- Adiciona utils para os testes do pacote `envreader`;
- Refatora os testes para usar as novas funções e os utils criados.