### PR TITLE
feat: adding httpserver package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ go get github.com/escaletech/go-escale
 
 [httpclient](./docs/httpclient.md)
 
+[httpserver](./docs/httpserver.md)
+
 [logger](./docs/logger.md)
 
-[requestid](./docs/requestid.md)
+[mongodb](./docs/mongodb.md)
 
 [mysqldb](./docs/mysqldb.md)
 
-[slicer](./docs/slicer.md)
+[requestid](./docs/requestid.md)
 
 [redis](./docs/redis.md)
 
-[mongodb](./docs/mongodb.md)
+[slicer](./docs/slicer.md)

--- a/docs/httpserver.md
+++ b/docs/httpserver.md
@@ -1,0 +1,7 @@
+# httpserver
+
+Funções helper para inicialização de servidor HTTP.
+
+## Funcionalidades
+
+- SetAddr

--- a/httpserver/serverAddress.go
+++ b/httpserver/serverAddress.go
@@ -1,0 +1,14 @@
+package httpserver
+
+// Appends "localhost" to address on webserver initialization,
+// when app env is "dev"
+//
+// (prevents macOS annoying Firewall request for authorization
+//	everytime the application restarts)
+func SetAddr(env, port string) string {
+	if env == "dev" {
+		return "localhost:" + port
+	}
+
+	return ":" + port
+}

--- a/httpserver/serverAddress_test.go
+++ b/httpserver/serverAddress_test.go
@@ -1,0 +1,31 @@
+package httpserver_test
+
+import (
+	"testing"
+
+	"github.com/escaletech/go-escale/httpserver"
+	"github.com/stretchr/testify/assert"
+)
+
+type cases struct {
+	env              string
+	port             string
+	expectedResponse string
+}
+
+func TestServerAddr(t *testing.T) {
+	testCases := []cases{
+		{"dev", "3000", "localhost:3000"},
+		{"staging", "666", ":666"},
+		{"production", "3000", ":3000"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("env is "+testCase.env+" and port is "+testCase.port, func(t *testing.T) {
+			t.Run("returns \""+testCase.expectedResponse+"\"", func(t *testing.T) {
+				addr := httpserver.SetAddr(testCase.env, testCase.port)
+				assert.Equal(t, testCase.expectedResponse, addr)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Adiciona a função `setAddr` para evitar aquele alert **CHATO PRA CARAMBA** do macOS toda vez que aplicação sobe com hot reload.