### PR TITLE
feat: adding ParseTime option to MySQL connection

### DIFF
--- a/mysqldb/gorm.go
+++ b/mysqldb/gorm.go
@@ -11,7 +11,7 @@ import (
 // Connect to a MySQL instance using Gorm
 func GormConnect(params GormConnParams) *gorm.DB {
 	db, err := gorm.Open(mysql.New(mysql.Config{
-		DSN:               params.ConnectionParams.DSN,
+		DSN:               setDSN(params.ConnectionParams.DSN, params.ConnectionParams.ParseTime),
 		DefaultStringSize: params.ConnectionParams.DefaultStringSize,
 	}), &gorm.Config{
 		Logger: *logger.NewGormLogger(params.Log, params.GormLoggerConfig),
@@ -27,4 +27,12 @@ func GormConnect(params GormConnParams) *gorm.DB {
 	sqlDB.SetMaxIdleConns(params.ConnectionParams.MaxIdleConns)
 
 	return db
+}
+
+func setDSN(dsn string, parseTime bool) string {
+	if parseTime {
+		dsn += "?parseTime=true"
+	}
+
+	return dsn
 }

--- a/mysqldb/type.go
+++ b/mysqldb/type.go
@@ -14,6 +14,7 @@ type ConnectionParams struct {
 	ConnMaxLifetime   time.Duration
 	MaxOpenConns      int
 	MaxIdleConns      int
+	ParseTime         bool
 }
 
 type GormConnParams struct {


### PR DESCRIPTION
Opção necessária para que seja possível associar o tipo `datetime` do MySQL ao tipo `time.Time` do Go.