### PR TITLE
feat: adding IsRecordNotFound error validation

### DIFF
--- a/mysqldb/gorm.go
+++ b/mysqldb/gorm.go
@@ -1,6 +1,8 @@
 package mysqldb
 
 import (
+	"errors"
+
 	"github.com/escaletech/go-escale/messages"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -35,4 +37,9 @@ func setDSN(dsn string, parseTime bool) string {
 	}
 
 	return dsn
+}
+
+// Check if returned error is a "Record not found" error
+func IsRecordNotFoundError(err error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
 }

--- a/mysqldb/gorm_test.go
+++ b/mysqldb/gorm_test.go
@@ -1,0 +1,41 @@
+package mysqldb_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/escaletech/go-escale/mysqldb"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+type cases struct {
+	description      string
+	err              error
+	expectedResponse bool
+}
+
+func TestIsRecordNotFoundError(t *testing.T) {
+	testCases := []cases{
+		{
+			"Error type is \"ErrRecordNotFound\"",
+			gorm.ErrRecordNotFound,
+			true,
+		},
+		{
+			"Error type is a generic one",
+			*new(error),
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			t.Run("returns "+strconv.FormatBool(testCase.expectedResponse), func(t *testing.T) {
+
+				resp := mysqldb.IsRecordNotFoundError(testCase.err)
+				assert.Equal(t, testCase.expectedResponse, resp)
+			})
+		})
+	}
+}


### PR DESCRIPTION
O GORM considera queries com 0 resultados como um erro. 
Em alguns cenários é necessário validar se o erro apresentado é esse, para não retornar um alerta pro usuário.