### PR TITLE
fix: set headers to be case sensitive

### DIFF
--- a/httpclient/httpClient.go
+++ b/httpclient/httpClient.go
@@ -54,7 +54,7 @@ func (h *HTTPClient) configClient(requestConfig Config) {
 
 func (h *HTTPClient) setHeaders(req *http.Request, headers map[string]string) *http.Request {
 	for key, value := range headers {
-		req.Header.Add(key, value)
+		req.Header[key] = []string{value}
 	}
 
 	return req


### PR DESCRIPTION
Da maneira "tradicional" (usando a função `Add`), o Go seta a primeira letra das chaves do `Header` para maiúsculo. Em alguns casos isso pode gerar erros no serviço de destino, já que tal cabeçalho deixa de ser identificado (esperando `user` e recebendo `User`).
Esse fix faz com que os headers sejam setados com a capitalização que o que o client enviou na configuração da requisição.