### PR TITLE
refactor: change type to std

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - sq/scanner
+      #- sq/scanner
 
 production_only: &production_only
   filters:

--- a/mongodb/mongodb.go
+++ b/mongodb/mongodb.go
@@ -26,7 +26,7 @@ func GetDatabase(mongoURL string) (*mongo.Database, error) {
 	return client.Database(cs.Database), nil
 }
 
-func EnsureIndex(collection *mongo.Collection, indexName string, keys bson.M, unique bool) error {
+func EnsureIndex(collection *mongo.Collection, indexName string, keys interface{}, unique bool) error {
 	if indexExists(collection, indexName) {
 		return nil
 	}


### PR DESCRIPTION
## Description
Change the type of function to allow **interface{}** as the argument instead **bson.M**

## Why this pull request is necessary

To allow create every kind of index using the same _EnsureIndex_ function.
As long the argument is used only in the struct below, it must be the same type.

```go
package mongo

...

type IndexModel struct {
    Keys    interface{}
    Options *options.IndexOptions
}
```